### PR TITLE
Add description and arguments to `demo_set_cam_position` command.

### DIFF
--- a/docs/references/engine/console-commands/demo-record-commands.md
+++ b/docs/references/engine/console-commands/demo-record-commands.md
@@ -16,4 +16,4 @@ ___
 |---|---|---|---|
 | demo_play | Plays the selected demo_record | "name" of demo | - |
 | demo_record | Enables recording of camera overflights | "name" of demo | Space bar sets key points when the camera flies The Enter key exits record mode and takes the player to the exit point from demo_record mode |
-| demo_set_cam_position |  |  | - |
+| demo_set_cam_position | Sets position of the demo camera | (x, y, z) | `x`, `y`, and `z` are 4-byte floats, i.e. in the range of -3.402823e+38 to 3.402823e+38. |


### PR DESCRIPTION
I missed this command in the docs because at a glance it didn't look like it took coordinate arguments.